### PR TITLE
issues/74 問卷字體樣式

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -155,6 +155,10 @@ class SurveysController < ApplicationController
       end
     end
   end
+
+  def font_style
+    @survey.update(font_style: params[:font_style])
+  end
   
   private
   def find_survey
@@ -166,6 +170,8 @@ class SurveysController < ApplicationController
       :title,
       :description,
       :position,
+      :font_style,
+      :theme,
       questions_attributes: [
         :_destroy,
         :id,

--- a/app/javascript/controllers/survey-style_controller.js
+++ b/app/javascript/controllers/survey-style_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "stimulus";
+import Rails from "@rails/ujs";
+
+
+export default class extends Controller {
+  static targets = [];
+
+  connect() {
+    // console.log(document.querySelector("form").children[2].dataset.id);
+     }
+
+  option(e) {
+    const id = document.querySelector("form").children[2].dataset.id
+    const form = document.querySelector("form")
+    const font_style =  e.target.value
+
+    
+    switch(font_style){
+      case "font-sans":
+        form.classList.remove("font-mono","font-serif");
+        form.classList.add("font-sans")
+        break;
+      case "font-mono":
+        form.classList.remove("font-serif","font-sans");
+        form.classList.add("font-mono");
+        break;
+      case "font-serif":
+        form.classList.remove("font-mono","font-sans");
+        form.classList.add("font-serif");
+        break;
+    }
+
+    const data = new FormData();
+    data.append("font_style", font_style);
+    console.log(id);
+    console.log(font_style);
+
+    Rails.ajax({
+      type: "patch",
+      url: `/surveys/${id}/font_style`,
+      data: data ,
+      success: (resp) => {},
+      error: (err) => {},
+    });
+
+  }
+
+}

--- a/app/javascript/controllers/survey-style_controller.js
+++ b/app/javascript/controllers/survey-style_controller.js
@@ -32,8 +32,6 @@ export default class extends Controller {
 
     const data = new FormData();
     data.append("font_style", font_style);
-    console.log(id);
-    console.log(font_style);
 
     Rails.ajax({
       type: "patch",

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -1,75 +1,77 @@
-<h1><%= @survey.title %></h1>
-<h2><%= @survey.description%></h2>
-<%= form_with(model: [@survey, response], url: responses_done_path) do |form| %>
-    <%= form.fields_for :answers do |response| %>
-    <% @survey.questions.each do |question| %>
-    <div class="question_field">
-        <h1 class="question_title">
-            <%= question.title %>
-            <%= content_tag :abbr, '*', title: 'Required' if question.required %>
-        </h1>
-
-    <div class="question_content">
-    <% case question.question_type %>
-    <% when 'single_choice' %>
-        <% question.answers.each do |answer| %>
-            <p>
-                <%= response.radio_button question.id, answer.id, required: question.required %>
-                <%= answer.title %>
-            </p>
-        <% end %>
-    <% when 'multiple_choice' %>
-        <% question.answers.each do |answer| %>
-        <p>
-                <%= response.check_box question.id, { multiple: true }, answer.id %>
-                <%= answer.title %>
-        </p>
-        <% end %>
-    <% when 'long_answer' %>
-        <%= response.text_area question.id, required: question.required %>
-    <% when 'satisfaction' %>
-        <table>
-            <tr>
-                <% question.answers.each do |answer| %>
-                    <td>
-                        <%= answer.title %>
-                    </td>
-                <% end %>
-            </tr>
-            <tr>
-                <% question.answers.each do |answer| %>
-                    <td>
-                        <%= response.radio_button question.id, answer.id %>
-                    </td>
-                <% end %>
-            </tr>
-        </table> 
-    <% when 'date' %>
-        <%= response.date_field question.id %>
-    <% when 'time' %>
-        <%= response.time_field question.id %>
-    <% when 'drop_down_menu' %>
-        <%= response.select question.id, options_for_select(question.answers.collect{ |o| [o.title, o.id] }) %>
+<section class="<%= @survey.font_style %>">
+    <h1><%= @survey.title %></h1>
+    <h2><%= @survey.description%></h2>
+    <%= form_with(model: [@survey, response], url: responses_done_path) do |form| %>
+        <%= form.fields_for :answers do |response| %>
+        <% @survey.questions.each do |question| %>
+        <div class="question_field">
+            <h1 class="question_title">
+                <%= question.title %>
+                <%= content_tag :abbr, '*', title: 'Required' if question.required %>
+            </h1>
     
-    <% when 'range' %>
-        <%= response.range_field question.id %>  
-    <% when 'file' %>
-        <%= response.file_field question.id, accept: "application/pdf, application/zip", multiple: true %>  
-    <% when 'image' %>
-    <%= file_field_tag question.id %>  
-        <% question.answers.each do |answer| %>
-            <%= response.image answer.answerimg.variant(resize_to_limit: [200, 300]) %>  
+        <div class="question_content">
+        <% case question.question_type %>
+        <% when 'single_choice' %>
+            <% question.answers.each do |answer| %>
+                <p>
+                    <%= response.radio_button question.id, answer.id, required: question.required %>
+                    <%= answer.title %>
+                </p>
+            <% end %>
+        <% when 'multiple_choice' %>
+            <% question.answers.each do |answer| %>
+            <p>
+                    <%= response.check_box question.id, { multiple: true }, answer.id %>
+                    <%= answer.title %>
+            </p>
+            <% end %>
+        <% when 'long_answer' %>
+            <%= response.text_area question.id, required: question.required %>
+        <% when 'satisfaction' %>
+            <table>
+                <tr>
+                    <% question.answers.each do |answer| %>
+                        <td>
+                            <%= answer.title %>
+                        </td>
+                    <% end %>
+                </tr>
+                <tr>
+                    <% question.answers.each do |answer| %>
+                        <td>
+                            <%= response.radio_button question.id, answer.id %>
+                        </td>
+                    <% end %>
+                </tr>
+            </table>
+        <% when 'date' %>
+            <%= response.date_field question.id %>
+        <% when 'time' %>
+            <%= response.time_field question.id %>
+        <% when 'drop_down_menu' %>
+            <%= response.select question.id, options_for_select(question.answers.collect{ |o| [o.title, o.id] }) %>
+    
+        <% when 'range' %>
+            <%= response.range_field question.id %>
+        <% when 'file' %>
+            <%= response.file_field question.id, accept: "application/pdf, application/zip", multiple: true %>
+        <% when 'image' %>
+        <%= file_field_tag question.id %>
+            <% question.answers.each do |answer| %>
+                <%= response.image answer.answerimg.variant(resize_to_limit: [200, 300]) %>
+            <% end %>
         <% end %>
+        </div>
+        </div>
+    
+    
+    
+        <% end %>
+      <% end %>
+    
+      <div class="actions">
+        <%= form.submit %>
+      </div>
     <% end %>
-    </div>
-    </div>
-
-
-
-    <% end %>
-  <% end %>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
+</section>

--- a/app/views/responses/show.html.erb
+++ b/app/views/responses/show.html.erb
@@ -1,50 +1,52 @@
-<h1><%= @survey.title %></h1>
-<h2><%= @survey.description%></h2>
-<% @survey.questions.each do |question| %>
-    <div class="question_field">
-    <h2 class="question_title"><%= question.title %></h2>
-    <div class="question_content">
-    <% case question.question_type %>
-    <% when 'single_choice' %>
-    <p><%= question.answers.find { |a| a.id.to_s == @response.answers[question.id.to_s] }.title %></p>
-    <% when 'multiple_choice' %>
-    <% question.answers.select { |a| @response.multiple_choice_answers(question.id).include?(a.id) }.each do |answer| %>
-        <p><%= answer.title %></p>
+<section class="<%= @survey.font_style %>">
+    <h1><%= @survey.title %></h1>
+    <h2><%= @survey.description%></h2>
+    <% @survey.questions.each do |question| %>
+        <div class="question_field">
+        <h2 class="question_title"><%= question.title %></h2>
+        <div class="question_content">
+        <% case question.question_type %>
+        <% when 'single_choice' %>
+        <p><%= question.answers.find { |a| a.id.to_s == @response.answers[question.id.to_s] }.title %></p>
+        <% when 'multiple_choice' %>
+        <% question.answers.select { |a| @response.multiple_choice_answers(question.id).include?(a.id) }.each do |answer| %>
+            <p><%= answer.title %></p>
+        <% end %>
+        <% when 'long_answer' %>
+        <p><%= @response.answers[question.id.to_s] %></p>
+        <% when 'satisfaction' %>
+        <table>
+            <tr>
+            <% question.answers.each do |answer| %>
+            <td>
+                <%= answer.title %>
+            </td>
+            <% end %>
+            </tr>
+            <tr>
+            <% question.answers.each do |answer| %>
+            <td>
+                <%= radio_button_tag question.id, answer.id , answer.id == @response.answers["#{question.id}"].to_i ? true : false %>
+            </td>
+            <% end %>
+            </tr>
+        </table>
+        <% when 'date' %>
+            <%= date_field_tag question.id, @response.answers["#{question.id}"]%>
+        <% when 'time' %>
+            <%= time_field_tag question.id, @response.answers["#{question.id}"] %>
+        <% when 'drop_down_menu' %>
+            <%= select_tag question.id, options_for_select(question.answers.collect{ |o| [o.title, o.id] }, @response.answers["#{question.id}"] ) %>
+        <% when 'range' %>
+            <%= range_field_tag question.id , @response.answers["#{question.id}"]  %>
+        <% when 'file' %>
+            <%= file_field_tag question.id, accept: "application/pdf, application/zip", multiple: true %>
+        <% when 'image' %>
+            <% question.answers.each do |answer| %>
+                <%= image_tag answer.answerimg.variant(resize_to_limit: [200, 300]) %>
+            <% end %>
+        <% end %>
+        </div>
+        </div>
     <% end %>
-    <% when 'long_answer' %>
-    <p><%= @response.answers[question.id.to_s] %></p>
-    <% when 'satisfaction' %>
-    <table>
-        <tr>
-        <% question.answers.each do |answer| %>
-        <td>
-            <%= answer.title %>
-        </td>
-        <% end %>
-        </tr>
-        <tr>
-        <% question.answers.each do |answer| %>
-        <td>
-            <%= radio_button_tag question.id, answer.id , answer.id == @response.answers["#{question.id}"].to_i ? true : false %>
-        </td>
-        <% end %>
-        </tr>
-    </table> 
-    <% when 'date' %>
-        <%= date_field_tag question.id, @response.answers["#{question.id}"]%>
-    <% when 'time' %>
-        <%= time_field_tag question.id, @response.answers["#{question.id}"] %>
-    <% when 'drop_down_menu' %>
-        <%= select_tag question.id, options_for_select(question.answers.collect{ |o| [o.title, o.id] }, @response.answers["#{question.id}"] ) %>
-    <% when 'range' %>
-        <%= range_field_tag question.id , @response.answers["#{question.id}"]  %>  
-    <% when 'file' %>
-        <%= file_field_tag question.id, accept: "application/pdf, application/zip", multiple: true %>  
-    <% when 'image' %>
-        <% question.answers.each do |answer| %>
-            <%= image_tag answer.answerimg.variant(resize_to_limit: [200, 300]) %>  
-        <% end %>
-    <% end %> 
-    </div>
-    </div>
-<% end %>
+</section>

--- a/app/views/surveys/_form.html.erb
+++ b/app/views/surveys/_form.html.erb
@@ -1,13 +1,15 @@
 <section class="max-w-lg mx-auto">
 
-<%= form_with(model: survey,  data: { controller: "auto-save", action: "change->auto-save#create_survey", auto_save_target: "form"}) do |form| %>
+<%= form_with(model: survey,  data: { controller: "auto-save survey-style", action: "change->auto-save#create_survey", auto_save_target: "form"}, class: survey.font_style) do |form| %>
   <div class="field survey_id" data-id="<%= survey.id %>">
     <%= form.label :title, "問卷名稱", class: "text-xl" %>
-    <%= form.text_field :title, placeholder: "請輸入問卷名稱", class: "appearance-none block w-full bg-gray-50 text-gray-700 border border-gray-300 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white", data: {action: "change->auto-save#add_survey_title "}%>
+    <%= form.text_field :title, placeholder: "請輸入問卷名稱", class: "appearance-none block w-full bg-gray-50 text-gray-700 border border-gray-300 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white", 
+    data: {action: "change->auto-save#add_survey_title "}%>
   </div>
   <div class="field">
     <%= form.label :description, "問卷敘述", class: "text-xl" %>
-    <%= form.text_area :description, placeholder: "問卷敘述", class: "appearance-none block w-full bg-gray-50 text-gray-700 border border-gray-300 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white", data: {action: "change->auto-save#add_survey_description "} %>
+    <%= form.text_area :description, placeholder: "問卷敘述", class: "appearance-none block w-full bg-gray-50 text-gray-700 border border-gray-300 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white",
+     data: {action: "change->auto-save#add_survey_description "} %>
   </div>
   
   <div data-controller="nested-form sortable-question" data-nested-form-index-value ="QUESTION_RECORD" >
@@ -29,12 +31,22 @@
   <% if survey.id == nil %>
     <div class="actions my-6">
       <%= form.submit "新增問卷", class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 mx-2 rounded-full" %>
-    </div>
+  </div>
   <% else %>
     <div class="actions my-6">
       <%= link_to '更新問卷', surveys_path, class: "bg-red-500 hover:bg-gray-700 text-white font-bold py-2 px-4 mx-2 rounded-full", data: { action: "auto-save#submitForm"}%>
     </div>
   <% end%>
+
+   <div data-controller="survey-style" > 
+    <%= form.select :font_style,
+        options_for_select([['請選擇字體', 'DD' ],['font-sans(default)', 'font-sans'], ['font-mono', 'font-mono'],['font-serif','font-serif']],
+         selected: form.object.font_style ),
+        {},
+        data: { action: "change -> survey-style#option"}    
+    %>
+  </div> 
+
 
 <% end %>
 </section>

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -1,64 +1,66 @@
-<h1><%= @survey.title %></h1>
-<h2><%= @survey.description %></h2>
-<% @survey.questions.each do |question| %>
-  <h2><%= question.title %></h2>
-
-  <% case question.question_type %>
-  <% when 'single_choice' %>
-    <% question.answers.each do |answer| %>
-      <p>
-        <%= radio_button_tag question.id, answer.id %>
-        <%= answer.title %>
-      </p>
-    <% end %>
-  <% when 'multiple_choice' %>
-    <% question.answers.each do |answer| %>
-      <p>
-        <%= check_box_tag question.id, answer.id %>
-        <%= answer.title %>
-      </p>
-    <% end %>
-  <% when 'long_answer' %>
-    <%= text_area_tag question.id %>
-  <% when 'satisfaction' %>
-    <table>
-      <tr>
+<section class="<%= @survey.font_style %>">
+  <h1><%= @survey.title %></h1>
+  <h2><%= @survey.description %></h2>
+  <% @survey.questions.each do |question| %>
+    <h2><%= question.title %></h2>
+  
+    <% case question.question_type %>
+    <% when 'single_choice' %>
       <% question.answers.each do |answer| %>
-        <td>
-          <%# radio_button_tag question.id, answer.id %>
-          <%= answer.title %>
-        </td>
-      <% end %>
-      </tr>
-      <tr>
-      <% question.answers.each do |answer| %>
-        <td>
+        <p>
           <%= radio_button_tag question.id, answer.id %>
-          <%# answer.title %>
-        </td>
+          <%= answer.title %>
+        </p>
       <% end %>
-      </tr>
-    </table>  
-  <% when 'date' %>
-    <%= date_field_tag question.id %>
-  <% when 'time' %>
-    <%= time_field_tag question.id %>
-  <% when 'drop_down_menu' %>
- 
-    <%= select_tag question.id, options_for_select(question.answers.collect{ |o| [o.title, o.id] }
-      ) %>
-    
-  <% when 'range' %>
-    <%= range_field_tag question.id %>  
-  <% when 'file' %>
-    <%= file_field_tag question.id, accept: "application/pdf, application/zip", multiple: true %>  
-  <% when 'image' %>
-    <%= file_field_tag question.id %>  
+    <% when 'multiple_choice' %>
       <% question.answers.each do |answer| %>
-        <%= image_tag answer.answerimg.variant(resize_to_limit: [200, 300]) %>  
+        <p>
+          <%= check_box_tag question.id, answer.id %>
+          <%= answer.title %>
+        </p>
       <% end %>
+    <% when 'long_answer' %>
+      <%= text_area_tag question.id %>
+    <% when 'satisfaction' %>
+      <table>
+        <tr>
+        <% question.answers.each do |answer| %>
+          <td>
+            <%# radio_button_tag question.id, answer.id %>
+            <%= answer.title %>
+          </td>
+        <% end %>
+        </tr>
+        <tr>
+        <% question.answers.each do |answer| %>
+          <td>
+            <%= radio_button_tag question.id, answer.id %>
+            <%# answer.title %>
+          </td>
+        <% end %>
+        </tr>
+      </table>
+    <% when 'date' %>
+      <%= date_field_tag question.id %>
+    <% when 'time' %>
+      <%= time_field_tag question.id %>
+    <% when 'drop_down_menu' %>
+  
+      <%= select_tag question.id, options_for_select(question.answers.collect{ |o| [o.title, o.id] }
+        ) %>
+  
+    <% when 'range' %>
+      <%= range_field_tag question.id %>
+    <% when 'file' %>
+      <%= file_field_tag question.id, accept: "application/pdf, application/zip", multiple: true %>
+    <% when 'image' %>
+      <%= file_field_tag question.id %>
+        <% question.answers.each do |answer| %>
+          <%= image_tag answer.answerimg.variant(resize_to_limit: [200, 300]) %>
+        <% end %>
+    <% end %>
   <% end %>
-<% end %>
+</section>
 
 <div>
 <%= link_to 'Edit', edit_survey_path(@survey) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,6 @@ Rails.application.routes.draw do
   
   resources :surveys do
 
-    member do
-      patch :font_style
-      patch :theme
-    end
-
     resources :responses
 
     member do
@@ -31,6 +26,8 @@ Rails.application.routes.draw do
       post :add_answer
       delete :remove_question
       delete :remove_answer
+      patch :font_style
+      patch :theme
     end 
 
     get 'duplicate', on: :member , to: "surveys#duplicate_survey"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,12 @@ Rails.application.routes.draw do
   post 'logout' => 'user_sessions#destroy', :as => :logout
   
   resources :surveys do
+
+    member do
+      patch :font_style
+      patch :theme
+    end
+
     resources :responses
 
     member do
@@ -25,7 +31,7 @@ Rails.application.routes.draw do
       post :add_answer
       delete :remove_question
       delete :remove_answer
-    end
+    end 
 
     get 'duplicate', on: :member , to: "surveys#duplicate_survey"
     patch :tag
@@ -40,4 +46,5 @@ Rails.application.routes.draw do
   
   get 'to/:survey_id' , as: 'responses_new' , to: 'responses#new'
   post 'to/:survey_id/done' , as: 'responses_done', to: 'responses#create'
+
 end

--- a/db/migrate/20220514071958_add_style_to_survey.rb
+++ b/db/migrate/20220514071958_add_style_to_survey.rb
@@ -1,0 +1,6 @@
+class AddStyleToSurvey < ActiveRecord::Migration[6.1]
+  def change
+    add_column :surveys, :font_style, :string, foreign_key: true
+    add_column :surveys, :theme, :string, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_12_042222) do
+ActiveRecord::Schema.define(version: 2022_05_14_071958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,13 +75,13 @@ ActiveRecord::Schema.define(version: 2022_05_12_042222) do
 
   create_table "questions", force: :cascade do |t|
     t.string "title"
-    t.integer "question_type", default: 0
+    t.integer "question_type"
     t.bigint "survey_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "required"
-    t.integer "position"
     t.string "timestamp"
+    t.integer "position"
     t.index ["survey_id"], name: "index_questions_on_survey_id"
   end
 
@@ -99,11 +99,13 @@ ActiveRecord::Schema.define(version: 2022_05_12_042222) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deleted_at"
-    t.integer "position"
     t.bigint "user_id", null: false
-    t.string "slug"
-    t.index ["slug"], name: "index_surveys_on_slug", unique: true
     t.string "tag"
+    t.string "slug"
+    t.integer "position"
+    t.string "font_style"
+    t.string "theme"
+    t.index ["slug"], name: "index_surveys_on_slug", unique: true
     t.index ["user_id"], name: "index_surveys_on_user_id"
   end
 


### PR DESCRIPTION
1. 可更換問卷字體樣式
2. 可自動儲存
3. 可渲染到 show（用於預覽）、response（用於分享出去的問卷） 等頁面

+ 問卷下方可選擇字體
<img width="771" alt="截圖 2022-05-16 上午1 55 15" src="https://user-images.githubusercontent.com/92732598/168486987-23a53b89-22f8-4f8a-8356-40b7c8b57aa4.png">
