### PR TITLE
Issues/119_new 單張response呈現在網頁上

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -67,20 +67,14 @@ class SurveysController < ApplicationController
   def stats
     question_ids = []
     question_titles = []
-    question_types = []
     answer_ids = []
     answer_titles = []
-    answer_question_ids = []
-    question_answer_data = []
     answers_counts = [0]
   
     # combine question and answers
     @survey.questions.each do |question|
       question_ids << question.id
       question_titles << question.title
-      question_types << question.question_type
-      question_answer_data << question.title
-      question_answer_data << question.question_type
 
       case question.question_type
       when 'multiple_choice', 'single_choice', 'satisfaction', 'drop_down_menu'
@@ -88,9 +82,7 @@ class SurveysController < ApplicationController
         question.answers.each do |answer|
           answer_ids << answer.id
           answer_titles << answer.title
-          answer_question_ids << answer.question_id
           if answer.question_id == question.id
-            question_answer_data << answer.title
             answers_count += 1
           end
         end
@@ -99,19 +91,15 @@ class SurveysController < ApplicationController
       
     end
    
-    @questionAnswerDatas = question_answer_data
-  
     # deal with responses  
     response_index = 0
-    response_answer_datas = []
+    response_question_index = 0
     response_answer_ids = []
     xls_answer_arrays = []
-
+    response_jsons = []
+    response_question_answers = []
+    
     @survey.responses.each do |response|
-      response_answer_datas << '==========================='
-      response_answer_datas << '第' + (response_index+1).to_s + '份'
-      response_answer_datas << '==========================='
-
       xls_answer_array = [response.created_at]
       key_index = 0
       while key_index < question_ids.length
@@ -120,8 +108,9 @@ class SurveysController < ApplicationController
         end
         key_index += 1
       end
+
       @survey.questions.each do |question|
-        response_answer_datas << question.title
+        response_question_answer = []
         current_response_answers = response.answers[question.id.to_s] 
         case question.question_type
         when 'multiple_choice'
@@ -132,10 +121,10 @@ class SurveysController < ApplicationController
               answer_index = 0
               while answer_index < answers_counts.sum
                 if current_response_answer == answer_ids[answer_index].to_s
-                  response_answer_datas << answer_titles[answer_index]
+                  response_question_answer << answer_titles[answer_index]
                   multiple_answers << answer_titles[answer_index]
-
                   response_answer_ids << answer_ids[answer_index]
+                  break
                 end
                 answer_index += 1
               end
@@ -147,9 +136,10 @@ class SurveysController < ApplicationController
           if current_response_answers.present?
             while answer_index < answers_counts.sum
               if current_response_answers == answer_ids[answer_index].to_s
-                response_answer_datas << answer_titles[answer_index]
+                response_question_answer << answer_titles[answer_index]
                 response_answer_ids << answer_ids[answer_index]
                 xls_answer_array << answer_titles[answer_index]
+                break
               end
               answer_index += 1
             end
@@ -157,21 +147,30 @@ class SurveysController < ApplicationController
             xls_answer_array << ''
           end
         when 'long_answer', 'date', 'time', 'range'
-          response_answer_datas << current_response_answers
+          response_question_answer << current_response_answers
           xls_answer_array << current_response_answers
-        xls_answer_arrays << xls_answer_array
+          xls_answer_arrays << xls_answer_array
         end
+
+        response_question_answers << response_question_answer
+
+        response_jsons[response_question_index] = {
+          responseIndex: response_index,
+          questionTitles: question.title,
+          responseAnswerTitles: response_question_answers[response_question_index],
+        }
+        response_question_index += 1
       end
       response_index += 1    
     end
 
+    @responseJsons = response_jsons
+    
     sum_of_response_answer_ids = []
 
     answer_ids.each do |answer_id|
       sum_of_response_answer_ids << response_answer_ids.count(answer_id)
     end
-
-    @responseAnswerDatas = response_answer_datas
 
     # create charts
     chart_index = 0
@@ -213,6 +212,7 @@ class SurveysController < ApplicationController
     @chart_options = chart_options
     @chart_count = chart_index
     @canvas_target_name = canvas_target_name
+
     #excel
     @questionTitles = question_titles.insert(0,'時間')
     @xlsAnswerArrays = xls_answer_arrays

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -11,11 +11,13 @@ export default class extends Controller {
     this.showSingleResponseTargets[0].classList.remove("hidden") //default show the first response
   }
 
-  hideAndShow() {
+  hideAndShow(e) {
     if (this.showResponsesTarget.className === "hidden"){
       this.showResponsesTarget.classList.remove("hidden")
+      e.target.textContent = "隱藏所有回應"
     } else {
       this.showResponsesTarget.classList.add("hidden")
+      e.target.textContent = "顯示所有回應"
     }
   }
 

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -24,7 +24,7 @@ export default class extends Controller {
   chartTypeSelect(e) {
     const selectedChartType = e.target.value // get type from select
     const targetIndex = e.target.closest(".canvasContainer").id // check which container we got
-    let currentCanvasTarget = this.canvas_barTarget // just a initial value
+    let currentCanvasTarget = this.canvasBarTarget // just a initial value
 
     // clear all charts first
     this.canvasBarTargets[targetIndex].closest(".canvasArea").classList.add("hidden")

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -1,12 +1,15 @@
 import { Controller } from "stimulus"
+// import Chart from "chart.js"
 
 export default class extends Controller {
-  static targets = ["showResponses", "canvasBar", "canvasPie", "canvasLine"];
+  static targets = ["showResponses", "showSingleResponse", "currentResponse", "canvasBar", "canvasPie", "canvasLine"];
 
   connect() {
     this.canvasBarTargets.forEach ((target)=>{
-      target.closest(".canvasArea").classList.remove("hidden")//default display with bar chart
-    }) 
+      target.closest(".canvasArea").classList.remove("hidden") //default display with bar chart
+    })
+
+    this.showSingleResponseTargets[0].classList.remove("hidden") //default show the first response
   }
 
   hideAndShow() {
@@ -20,13 +23,13 @@ export default class extends Controller {
   chartTypeSelect(e) {
     const selectedChartType = e.target.value // get type from select
     const targetIndex = e.target.closest(".canvasContainer").id // check which container we got
-    let currentCanvasTarget = this.canvasBarTarget // just a initial value
+    let currentCanvasTarget = this.canvas_barTarget // just a initial value
 
     // clear all charts first
     this.canvasBarTargets[targetIndex].closest(".canvasArea").classList.add("hidden")
     this.canvasPieTargets[targetIndex].closest(".canvasArea").classList.add("hidden")
     this.canvasLineTargets[targetIndex].closest(".canvasArea").classList.add("hidden")
-      
+
     switch (selectedChartType) {
       case 'pie':
         currentCanvasTarget = this.canvasPieTargets[targetIndex]
@@ -39,9 +42,25 @@ export default class extends Controller {
         currentCanvasTarget = this.canvasBarTargets[targetIndex]
         break
     }
-      
+
     if (currentCanvasTarget.getAttribute("data-chart-type-value")===selectedChartType) {
       currentCanvasTarget.closest(".canvasArea").classList.remove("hidden") // only show the type we selected
     }
+  }
+
+  nextPage() {
+    let currentResponse = Number(this.currentResponseTarget.textContent)
+
+    this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
+    this.showSingleResponseTargets[currentResponse].classList.remove("hidden")
+    this.currentResponseTarget.textContent = currentResponse + 1
+  }
+
+  previousPage() {
+    let currentResponse = Number(this.currentResponseTarget.textContent)
+
+    this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
+    this.showSingleResponseTargets[currentResponse-2].classList.remove("hidden")
+    this.currentResponseTarget.textContent = currentResponse - 1
   }
 }

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -2,8 +2,7 @@ import { Controller } from "stimulus"
 // import Chart from "chart.js"
 
 export default class extends Controller {
-  static targets = ["showResponses", "showSingleResponse", "currentResponse", "canvasBar", "canvasPie", "canvasLine"];
-
+  static targets = ["showResponses", "showSingleResponse", "currentResponse","responsesCount", "canvasBar", "canvasPie", "canvasLine"];
   connect() {
     this.canvasBarTargets.forEach ((target)=>{
       target.closest(".canvasArea").classList.remove("hidden") //default display with bar chart
@@ -50,17 +49,26 @@ export default class extends Controller {
 
   nextPage() {
     let currentResponse = Number(this.currentResponseTarget.textContent)
+    let responsesCount = Number(this.responsesCountTarget.textContent)
 
-    this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
-    this.showSingleResponseTargets[currentResponse].classList.remove("hidden")
-    this.currentResponseTarget.textContent = currentResponse + 1
+    if (currentResponse < responsesCount) {
+      this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
+      this.showSingleResponseTargets[currentResponse].classList.remove("hidden")
+      this.currentResponseTarget.textContent = currentResponse + 1
+    } else {
+      alert("已經是最後一份囉")
+    }
   }
 
   previousPage() {
     let currentResponse = Number(this.currentResponseTarget.textContent)
 
-    this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
-    this.showSingleResponseTargets[currentResponse-2].classList.remove("hidden")
-    this.currentResponseTarget.textContent = currentResponse - 1
+    if (currentResponse > 1) {
+      this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
+      this.showSingleResponseTargets[currentResponse-2].classList.remove("hidden")
+      this.currentResponseTarget.textContent = currentResponse - 1
+    } else {
+      alert("已經是第一份囉")
+    }
   }
 }

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus"
 // import Chart from "chart.js"
 
 export default class extends Controller {
-  static targets = ["showResponses", "showSingleResponse", "currentResponse", "responsesCount", "canvasBar", "canvasPie", "canvasLine"];
+  static targets = ["showResponses", "showSingleResponse", "currentResponse", "responsesCount", "previousPageButton", "nextPageButton", "canvasBar", "canvasPie", "canvasLine"];
   connect() {
     this.canvasBarTargets.forEach ((target)=>{
       target.closest(".canvasArea").classList.remove("hidden") //default display with bar chart
@@ -49,28 +49,37 @@ export default class extends Controller {
     }
   }
 
-  nextPage() {
+  nextPage(e) {
     let currentResponse = Number(this.currentResponseTarget.textContent)
     let responsesCount = Number(this.responsesCountTarget.textContent)
 
+    if (currentResponse >= 1) {
+      this.previousPageButtonTarget.classList.remove("hidden")
+    }
     if (currentResponse < responsesCount) {
       this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
       this.showSingleResponseTargets[currentResponse].classList.remove("hidden")
-      this.currentResponseTarget.textContent = currentResponse + 1
-    } else {
-      alert("已經是最後一份囉")
+      this.currentResponseTarget.textContent = ++currentResponse
+      if (currentResponse == responsesCount) {
+        e.target.classList.add("hidden")
+      }
     }
   }
 
-  previousPage() {
+  previousPage(e) {
     let currentResponse = Number(this.currentResponseTarget.textContent)
+    let responsesCount = Number(this.responsesCountTarget.textContent)
 
+    if (currentResponse <= responsesCount) {
+      this.nextPageButtonTarget.classList.remove("hidden")
+    }
     if (currentResponse > 1) {
       this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
       this.showSingleResponseTargets[currentResponse-2].classList.remove("hidden")
-      this.currentResponseTarget.textContent = currentResponse - 1
-    } else {
-      alert("已經是第一份囉")
+      this.currentResponseTarget.textContent = --currentResponse
+      if (currentResponse == 1) {
+        e.target.classList.add("hidden")
+      }
     }
   }
 

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "stimulus"
 // import Chart from "chart.js"
 
 export default class extends Controller {
-  static targets = ["showResponses", "showSingleResponse", "currentResponse","responsesCount", "canvasBar", "canvasPie", "canvasLine"];
+  static targets = ["showResponses", "showSingleResponse", "currentResponse", "responsesCount", "canvasBar", "canvasPie", "canvasLine"];
   connect() {
     this.canvasBarTargets.forEach ((target)=>{
       target.closest(".canvasArea").classList.remove("hidden") //default display with bar chart
@@ -71,6 +71,20 @@ export default class extends Controller {
       this.currentResponseTarget.textContent = currentResponse - 1
     } else {
       alert("已經是第一份囉")
+    }
+  }
+
+  jumpToPage(e) {
+    let jumpToPageNumber = e.target.value
+    let currentResponse = Number(this.currentResponseTarget.textContent)
+    let responsesCount = Number(this.responsesCountTarget.textContent)
+
+    if (jumpToPageNumber > 0 && jumpToPageNumber <= responsesCount) {
+      this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
+      this.showSingleResponseTargets[jumpToPageNumber-1].classList.remove("hidden")
+      this.currentResponseTarget.textContent = jumpToPageNumber
+    } else {
+      alert("沒有這頁喔")
     }
   }
 }

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -67,7 +67,6 @@ export default class extends Controller {
 
   previousPage(e) {
     let currentResponse = Number(this.currentResponseTarget.textContent)
-    let responsesCount = Number(this.responsesCountTarget.textContent)
 
     this.nextPageButtonTarget.classList.remove("hidden")
 

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -53,9 +53,8 @@ export default class extends Controller {
     let currentResponse = Number(this.currentResponseTarget.textContent)
     let responsesCount = Number(this.responsesCountTarget.textContent)
 
-    if (currentResponse >= 1) {
-      this.previousPageButtonTarget.classList.remove("hidden")
-    }
+    this.previousPageButtonTarget.classList.remove("hidden")
+
     if (currentResponse < responsesCount) {
       this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
       this.showSingleResponseTargets[currentResponse].classList.remove("hidden")
@@ -70,9 +69,8 @@ export default class extends Controller {
     let currentResponse = Number(this.currentResponseTarget.textContent)
     let responsesCount = Number(this.responsesCountTarget.textContent)
 
-    if (currentResponse <= responsesCount) {
-      this.nextPageButtonTarget.classList.remove("hidden")
-    }
+    this.nextPageButtonTarget.classList.remove("hidden")
+
     if (currentResponse > 1) {
       this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
       this.showSingleResponseTargets[currentResponse-2].classList.remove("hidden")
@@ -88,12 +86,21 @@ export default class extends Controller {
     let currentResponse = Number(this.currentResponseTarget.textContent)
     let responsesCount = Number(this.responsesCountTarget.textContent)
 
+    this.previousPageButtonTarget.classList.remove("hidden")
+    this.nextPageButtonTarget.classList.remove("hidden")
+
     if (jumpToPageNumber > 0 && jumpToPageNumber <= responsesCount) {
       this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
       this.showSingleResponseTargets[jumpToPageNumber-1].classList.remove("hidden")
       this.currentResponseTarget.textContent = jumpToPageNumber
     } else {
       alert("沒有這頁喔")
+    }
+    if (jumpToPageNumber == 1) {
+      this.previousPageButtonTarget.classList.add("hidden")
+    }
+    if (jumpToPageNumber == responsesCount) {
+      this.nextPageButtonTarget.classList.add("hidden")
     }
   }
 }

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -11,23 +11,23 @@
               <p class="font-light font-mono text-sm text-gray-700 hover:text-gray-900 transition-all duration-200  truncate "><%= survey.description %></p> 
               <div class="mt-5 flex justify-end">
                              
-                  <%= link_to edit_survey_path(survey), class: "linkbtn" do %>
+                  <%= link_to edit_survey_path(survey), title: "編輯問卷", class: "linkbtn" do %>
                     <i class="fas fa-pen"></i>
                   <% end %>
 
-                <%= link_to duplicate_survey_path(survey), class: "linkbtn" do %>
+                <%= link_to duplicate_survey_path(survey), title: "複製問卷", class: "linkbtn" do %>
                   <i class="fas fa-copy"></i>
                 <% end %>
                 
-                <%= link_to "#", data: {action:"click->modal#open click->surveys#share" ,url: responses_new_path(survey) }, class: "linkbtn" do %>
+                <%= link_to "#", title: "分享問卷", data: {action:"click->modal#open click->surveys#share" ,url: responses_new_path(survey) }, class: "linkbtn" do %>
                   <i class="fas fa-share"></i>
                 <% end %>
 
-                <%= link_to stats_survey_path(survey), title: "統計數據管理", class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-1 px-2 mx-2 rounded-full" do %>
+                <%= link_to stats_survey_path(survey), title: "統計數據管理", class: "linkbtn" do %>
                   <i class="fas fa-chart-pie"></i>
                 <% end %>
               
-                <%= link_to survey, method: :delete, data: { confirm: '確定要刪除問卷嗎?' }, class: "linkbtn" do%>
+                <%= link_to survey, title: "刪除問卷", method: :delete, data: { confirm: '確定要刪除問卷嗎?' }, class: "linkbtn" do%>
                   <i class="fas fa-trash-alt"></i>
                 <% end %>
               </div>

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -7,7 +7,7 @@
 <div data-controller="stats">
   <button data-action="click->stats#hideAndShow">顯示所有回應</button>
   <div data-stats-target="showResponses" class="hidden">
-    <h2>填答份數: <%= @survey.responses.count %></h2>
+    <h2>填答份數: <span data-stats-target="responsesCount"><%= @survey.responses.count %></span></h2>
     <h2>目前顯示: 第<span data-stats-target="currentResponse">1</span>份</h2>
     <% 0.upto(@survey.responses.count-1) do |responseIndex| %>
       <div data-stats-target="showSingleResponse", class="hidden">

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -11,13 +11,16 @@
     <h2>目前顯示: 第<span data-stats-target="currentResponse">1</span>份</h2>
     <% 0.upto(@survey.responses.count-1) do |responseIndex| %>
       <div data-stats-target="showSingleResponse", class="hidden">
-        <% @responseJsons.each do |responseJson| %>
-          <% if responseJson.as_json["responseIndex"] === responseIndex %>
-            <h2><%= responseJson.as_json["questionTitles"] %></h2>
-            <h2><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></h2>
-            <br>
+        <table class="table-auto">
+          <% @responseJsons.each do |responseJson| %>
+            <% if responseJson.as_json["responseIndex"] === responseIndex %>
+              <tr>
+                <th class="bg-gentleYellow text-ironGray"><%= responseJson.as_json["questionTitles"] %></th>
+                <td><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></td>
+              </tr>
+            <% end %>
           <% end %>
-        <% end %>
+        </table>
       </div>
     <% end %>
     <button data-action="click->stats#previousPage">上一份</button><button data-action="click->stats#nextPage">下一份</button>

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -8,9 +8,19 @@
   <button data-action="click->stats#hideAndShow">顯示所有回應</button>
   <div data-stats-target="showResponses" class="hidden">
     <h2>填答份數: <%= @survey.responses.count %></h2>
-    <% @responseAnswerDatas.each do |responseAnswerData| %>
-      <h2><%= responseAnswerData %></h2>
+    <h2>目前顯示: 第<span data-stats-target="currentResponse">1</span>份</h2>
+    <% 0.upto(@survey.responses.count-1) do |responseIndex| %>
+      <div data-stats-target="showSingleResponse", class="hidden">
+        <% @responseJsons.each do |responseJson| %>
+          <% if responseJson.as_json["responseIndex"] === responseIndex %>
+            <h2><%= responseJson.as_json["questionTitles"] %></h2>
+            <h2><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></h2>
+            <br>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
+    <button data-action="click->stats#previousPage">上一份</button><button data-action="click->stats#nextPage">下一份</button>
   </div>
 
   <hr>
@@ -35,5 +45,5 @@
 </div>
 
 <br>
-
+<%= link_to 'back', surveys_path %>
 <%= link_to 'Download as .xlsx', stats_survey_path(format: :xlsx) %>

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -31,7 +31,7 @@
   <hr>
   <div>
     <% 0.upto(@chart_count-1) do |chart_index| %>
-      <div id="<%= chart_index.to_s %>" class="canvasContainer">
+      <div id="<%= chart_index %>" class="canvasContainer">
         <%= select_tag(:chart_type, options_for_select([['長條圖', 'bar'], ['圓餅圖', 'pie'], ['折線圖', 'line']]), data: { action: "change->stats#chartTypeSelect"}) %>
         <% 0.upto(@chart_types.count-1) do |chart_type_index| %>
           <div class="hidden canvasArea">

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -23,7 +23,9 @@
         </table>
       </div>
     <% end %>
-    <button data-action="click->stats#previousPage">上一份</button><button data-action="click->stats#nextPage">下一份</button>
+    <button data-action="click->stats#previousPage">上一份</button>
+    <button data-action="click->stats#nextPage">下一份</button>
+    跳轉到:<input data-action="change->stats#jumpToPage" placeholder="輸入頁數"></input>
   </div>
 
   <hr>

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -23,8 +23,8 @@
         </table>
       </div>
     <% end %>
-    <button data-action="click->stats#previousPage">上一份</button>
-    <button data-action="click->stats#nextPage">下一份</button>
+    <button data-stats-target="previousPageButton" data-action="click->stats#previousPage" class="hidden">上一份</button>
+    <button data-stats-target="nextPageButton" data-action="click->stats#nextPage">下一份</button>
     跳轉到:<input data-action="change->stats#jumpToPage" placeholder="輸入頁數"></input>
   </div>
 


### PR DESCRIPTION
#119 
1. 資料呈現方式改成秀單個回應，可按上一份下一份或跳轉到特定頁數
2. 修改統計數據按鈕樣式
3. 幫每個按鈕加上功能註解
5/30立會中提到的chart中的簡答題列表呈現不算此票範圍，會放在下一張票stats page切版中一起做
https://user-images.githubusercontent.com/78979239/170820474-f8806240-7062-4bfb-862c-c657ee6e159c.mov

