### PR TITLE
issues/124 題型名稱由英文改成中文

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -83,7 +83,7 @@ class SurveysController < ApplicationController
       question_answer_data << question.question_type
 
       case question.question_type
-      when 'multiple_choice', 'single_choice', 'satisfaction', 'drop_down_menu'
+      when '多選題', '單選題', '滿意度', '下拉選單'
         answers_count = 0
         question.answers.each do |answer|
           answer_ids << answer.id
@@ -124,7 +124,7 @@ class SurveysController < ApplicationController
         response_answer_datas << question.title
         current_response_answers = response.answers[question.id.to_s] 
         case question.question_type
-        when 'multiple_choice'
+        when '多選題'
           if current_response_answers.present?
             current_response_answers.delete('0')
             multiple_answers = []
@@ -142,7 +142,7 @@ class SurveysController < ApplicationController
             end
             xls_answer_array << multiple_answers.join(', ')
           end
-        when 'single_choice', 'satisfaction', 'drop_down_menu'
+        when '單選題', '滿意度', '下拉選單'
           answer_index = 0
           if current_response_answers.present?
             while answer_index < answers_counts.sum
@@ -156,7 +156,7 @@ class SurveysController < ApplicationController
           else
             xls_answer_array << ''
           end
-        when 'long_answer', 'date', 'time', 'range'
+        when '問答題', '日期', '時間', '範圍'
           response_answer_datas << current_response_answers
           xls_answer_array << current_response_answers
         xls_answer_arrays << xls_answer_array
@@ -183,7 +183,7 @@ class SurveysController < ApplicationController
     
     @survey.questions.each do |question|
       case question.question_type
-      when 'multiple_choice' , 'single_choice', 'satisfaction', 'drop_down_menu'
+      when '多選題' , '單選題', '滿意度', '下拉選單'
           
         slice_from += answers_counts[chart_index]
         slice_length = answers_counts[chart_index+1]  


### PR DESCRIPTION
#124 
因merge issues/107問卷狀態設定 這張票後，題目題型名稱由英文改成中文，會讓圖表無法呈現，此票是把題型改為中文