### PR TITLE
stats頁面切版及新增show出每個問題的response list

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -212,9 +212,23 @@ class SurveysController < ApplicationController
         }
 
         chart_options[chart_index] = {
+          plugins: {
+            title: {
+              display: true,
+              text: question.title
+            }
+          },
           layout: {
             padding: 50
-          }
+          },
+          scales: {
+            y: {
+              ticks: {
+                stepSize: 1
+              },
+              beginAtZero: true
+            }
+          },
         }   
         
         chart_index += 1

--- a/app/javascript/controllers/stats_controller.js
+++ b/app/javascript/controllers/stats_controller.js
@@ -1,23 +1,47 @@
 import { Controller } from "stimulus"
-// import Chart from "chart.js"
 
 export default class extends Controller {
-  static targets = ["showResponses", "showSingleResponse", "currentResponse", "responsesCount", "previousPageButton", "nextPageButton", "canvasBar", "canvasPie", "canvasLine"];
+  static targets = ["showResponses",
+                    "showSingleResponse", 
+                    "currentResponse", 
+                    "responsesCount", 
+                    "showQuestions",
+                    "showSingleQuestion",
+                    "questionsCount",
+                    "currentQuestion",
+                    "showCharts",
+                    "previousPageButton", 
+                    "nextPageButton", 
+                    "canvasBar", 
+                    "canvasPie", 
+                    "canvasLine"];
   connect() {
     this.canvasBarTargets.forEach ((target)=>{
       target.closest(".canvasArea").classList.remove("hidden") //default display with bar chart
     })
 
     this.showSingleResponseTargets[0].classList.remove("hidden") //default show the first response
+    this.showSingleQuestionTargets[0].classList.remove("hidden")
   }
 
   hideAndShow(e) {
-    if (this.showResponsesTarget.className === "hidden"){
-      this.showResponsesTarget.classList.remove("hidden")
-      e.target.textContent = "隱藏所有回應"
-    } else {
-      this.showResponsesTarget.classList.add("hidden")
-      e.target.textContent = "顯示所有回應"
+    this.showChartsTarget.classList.add("hidden") //clear all first
+    this.showQuestionsTarget.classList.add("hidden")
+    this.showResponsesTarget.classList.add("hidden")
+
+    switch (e.target.id) {
+      case "showResponsesBtn":
+        console.log("showResponsesBtn")
+        this.showResponsesTarget.classList.remove("hidden")
+        break
+      case "showQuestionsBtn":
+        console.log("showQuestionsBtn")
+        this.showQuestionsTarget.classList.remove("hidden")
+        break
+      case "showChartsBtn":
+        console.log("showChartsBtn")
+        this.showChartsTarget.classList.remove("hidden")
+        break
     }
   }
 
@@ -49,57 +73,81 @@ export default class extends Controller {
     }
   }
 
-  nextPage(e) {
-    let currentResponse = Number(this.currentResponseTarget.textContent)
-    let responsesCount = Number(this.responsesCountTarget.textContent)
+  nextPage(target, targetCount, showTargets, currentTarget, targetIndex) {
+    let currentResponse = Number(target.textContent)
+    const responsesCount = Number(targetCount.textContent)
 
-    this.previousPageButtonTarget.classList.remove("hidden")
+    this.previousPageButtonTargets[targetIndex].classList.remove("hidden")
 
     if (currentResponse < responsesCount) {
-      this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
-      this.showSingleResponseTargets[currentResponse].classList.remove("hidden")
-      this.currentResponseTarget.textContent = ++currentResponse
+      showTargets[currentResponse-1].classList.add("hidden")
+      showTargets[currentResponse].classList.remove("hidden")
+      target.textContent = ++currentResponse
       if (currentResponse == responsesCount) {
-        e.target.classList.add("hidden")
+        currentTarget.classList.add("hidden")
       }
     }
   }
 
-  previousPage(e) {
-    let currentResponse = Number(this.currentResponseTarget.textContent)
+  previousPage(target, showTargets, currentTarget, targetIndex) {
+    let currentResponse = Number(target.textContent)
 
-    this.nextPageButtonTarget.classList.remove("hidden")
+    this.nextPageButtonTargets[targetIndex].classList.remove("hidden")
 
     if (currentResponse > 1) {
-      this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
-      this.showSingleResponseTargets[currentResponse-2].classList.remove("hidden")
-      this.currentResponseTarget.textContent = --currentResponse
+      showTargets[currentResponse-1].classList.add("hidden")
+      showTargets[currentResponse-2].classList.remove("hidden")
+      target.textContent = --currentResponse
       if (currentResponse == 1) {
-        e.target.classList.add("hidden")
+        currentTarget.classList.add("hidden")
       }
     }
   }
 
-  jumpToPage(e) {
-    let jumpToPageNumber = e.target.value
-    let currentResponse = Number(this.currentResponseTarget.textContent)
-    let responsesCount = Number(this.responsesCountTarget.textContent)
+  jumpToPage(target, targetCount, showTargets, currentTarget, targetIndex) {
+    let currentResponse = Number(target.textContent)
+    const responsesCount = Number(targetCount.textContent)
+    const jumpToPageNumber = currentTarget.value
 
-    this.previousPageButtonTarget.classList.remove("hidden")
-    this.nextPageButtonTarget.classList.remove("hidden")
+    this.previousPageButtonTargets[targetIndex].classList.remove("hidden")
+    this.nextPageButtonTargets[targetIndex].classList.remove("hidden")
 
     if (jumpToPageNumber > 0 && jumpToPageNumber <= responsesCount) {
-      this.showSingleResponseTargets[currentResponse-1].classList.add("hidden")
-      this.showSingleResponseTargets[jumpToPageNumber-1].classList.remove("hidden")
-      this.currentResponseTarget.textContent = jumpToPageNumber
+      showTargets[currentResponse-1].classList.add("hidden")
+      showTargets[jumpToPageNumber-1].classList.remove("hidden")
+      target.textContent = jumpToPageNumber
     } else {
       alert("沒有這頁喔")
     }
     if (jumpToPageNumber == 1) {
-      this.previousPageButtonTarget.classList.add("hidden")
+      this.previousPageButtonTargets[targetIndex].classList.add("hidden")
     }
     if (jumpToPageNumber == responsesCount) {
-      this.nextPageButtonTarget.classList.add("hidden")
+      this.nextPageButtonTargets[targetIndex].classList.add("hidden")
     }
+  }
+
+  nextResponse(e) {
+    this.nextPage(this.currentResponseTarget, this.responsesCountTarget, this.showSingleResponseTargets, e.target, this.showResponsesTarget.id)
+  }
+
+  previousResponse(e) {
+    this.previousPage(this.currentResponseTarget, this.showSingleResponseTargets, e.target, this.showResponsesTarget.id)
+  }
+
+  jumpToResponse(e) {
+    this.jumpToPage(this.currentResponseTarget, this.responsesCountTarget, this.showSingleResponseTargets, e.target, this.showResponsesTarget.id)
+  }
+
+  nextQuestion(e) {
+    this.nextPage(this.currentQuestionTarget, this.questionsCountTarget, this.showSingleQuestionTargets, e.target, this.showQuestionsTarget.id)
+  }
+
+  previousQuestion(e) {
+    this.previousPage(this.currentQuestionTarget, this.showSingleQuestionTargets, e.target, this.showQuestionsTarget.id)
+  }
+
+  jumpToQuestion(e) {
+    this.jumpToPage(this.currentQuestionTarget, this.questionsCountTarget, this.showSingleQuestionTargets, e.target, this.showQuestionsTarget.id)
   }
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "./submitted_responses.scss";
 @import "./new_responses.scss";
 @import "./homepage.scss";
+@import "./stats.scss";
 
 input,
 textarea,

--- a/app/javascript/stylesheets/stats.scss
+++ b/app/javascript/stylesheets/stats.scss
@@ -1,23 +1,43 @@
 .padding-for-fixed-stats{
-    @apply pt-20;
-  }
+  padding-top: 80px;
+}
   
-  .stats-tab-button{
-    @apply px-4 py-3 font-bold bg-gentleYellow hover:bg-ironGray;
-  }
+.stats-tab-button{
+  @apply px-4 py-3 font-bold bg-gentleYellow hover:bg-softOrange;
+}
   
-  .stats-display-area{
-    @apply bg-gentleYellow mx-2 px-4 py-4 min-h-screen;
-  }
+.stats-display-area{
+  @apply flex bg-gentleYellow mx-2 px-4 py-4 min-h-screen;
+}
+
+.survey-info-area{
+  @apply bg-gentleYellow w-60;
+}
   
-  .input-jump-to-page{
-    @apply w-16;
-  }
+.canvasContainer{
+  width: 560px;
+}
+
+.page-button{
+  @apply hover:bg-softOrange;
+}
+
+.input-jump-to-page{
+  @apply w-16;
+}
   
-  .table-style{
-    @apply border-solid border-2 border-black text-xl;
-  }
+.table-style{
+  @apply border-solid border-2 border-yellow-900 text-2xl shadow-xl;
+}
+
+.th-style{
+  @apply bg-softOrange text-2xl shadow-xl;
+}
+
+.td-style{
+  @apply bg-gentleYellow text-2xl shadow-xl;
+}
   
-  .taglabel{
-    @apply inline-block bg-irisBlue align-middle rounded-2xl px-2.5 py-1 text-xs text-white font-medium mr-1 mb-1 border-solid border break-all break-all;
-  }
+.taglabel{
+  @apply inline-block bg-irisBlue align-middle rounded-2xl px-2.5 py-1 text-xs text-white font-medium mr-1 mb-1 border-solid border break-all break-all;
+}

--- a/app/javascript/stylesheets/stats.scss
+++ b/app/javascript/stylesheets/stats.scss
@@ -1,0 +1,23 @@
+.padding-for-fixed-stats{
+    @apply pt-20;
+  }
+  
+  .stats-tab-button{
+    @apply px-4 py-3 font-bold bg-gentleYellow hover:bg-ironGray;
+  }
+  
+  .stats-display-area{
+    @apply bg-gentleYellow mx-2 px-4 py-4 min-h-screen;
+  }
+  
+  .input-jump-to-page{
+    @apply w-16;
+  }
+  
+  .table-style{
+    @apply border-solid border-2 border-black text-xl;
+  }
+  
+  .taglabel{
+    @apply inline-block bg-irisBlue align-middle rounded-2xl px-2.5 py-1 text-xs text-white font-medium mr-1 mb-1 border-solid border break-all break-all;
+  }

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="stats" class="px-1 padding-for-fixed-stats min-hight">
+<div data-controller="stats" class="min-h-screen px-1 padding-for-fixed-stats">
   <div class="flex mx-2 bg-gentleYellow">
     <button id="showResponsesBtn" class="stats-tab-button" data-action="click->stats#hideAndShow">所有回應</button><br>
     <button id="showQuestionsBtn" class="stats-tab-button" data-action="click->stats#hideAndShow">數據統計</button><br>
@@ -6,23 +6,24 @@
     <button class="stats-tab-button"><%= link_to '匯出Excel檔案', stats_survey_path(format: :xlsx) %></button></br>
   </div>
   <div class="stats-display-area">
-    <h1 class="px-2 mx-2 text-3xl font-bold text-gray-700"><%= @survey.title %></h1>
-    <h2 class="px-2 mx-2 text-lg font-bold text-gray-500"><%= @survey.description %></h2>
-    <br>
-    <div class="mx-4">
-      <% if @survey.tag.present? %>
-        <% @survey.tag.split(',') do |currentTag| %>
-          <h2 class="taglabel"><%= currentTag %></h2>
+    <div class="survey-info-area">
+      <h1 class="px-2 mx-2 text-3xl font-bold text-gray-700"><%= @survey.title %></h1>
+      <h2 class="px-2 mx-2 text-lg font-bold text-gray-500"><%= @survey.description %></h2>
+      <div class="mx-4">
+        <% if @survey.tag.present? %>
+          <% @survey.tag.split(',') do |currentTag| %>
+            <h2 class="taglabel"><%= currentTag %></h2>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
     </div>
     <br>
     <div data-stats-target="showResponses" id=0 class="hidden">
       <h2 class="text-xl font-bold">填答份數: <span data-stats-target="responsesCount"><%= @survey.responses.count %></span></h2>
       <h2 class="text-xl font-bold">目前顯示: 第<span data-stats-target="currentResponse">1</span>份</h2>
       <br>
-      <button class="hidden hover:bg-ironGrayHover" data-stats-target="previousPageButton" data-action="click->stats#previousResponse">上一份</button>
-      <button class="hover:bg-ironGrayHover" data-stats-target="nextPageButton" data-action="click->stats#nextResponse">下一份</button>
+      <button class="hidden page-button" data-stats-target="previousPageButton" data-action="click->stats#previousResponse">上一份</button>
+      <button class="page-button" data-stats-target="nextPageButton" data-action="click->stats#nextResponse">下一份</button>
       跳轉到:<input class="input-jump-to-page" data-action="change->stats#jumpToResponse" placeholder="輸入頁數"></input>
       <% 0.upto(@survey.responses.count-1) do |responseIndex| %>
         <div data-stats-target="showSingleResponse", class="hidden">
@@ -30,8 +31,8 @@
             <% @responseJsons.each do |responseJson| %>
               <% if responseJson.as_json["responseIndex"] === responseIndex %>
                 <tr>
-                  <th class="table-style"><%= responseJson.as_json["questionTitles"] %></th>
-                  <td class="table-style"><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></td>
+                  <th class="th-style"><%= responseJson.as_json["questionTitles"] %></th>
+                  <td class="td-style"><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></td>
                 </tr>
               <% end %>
             <% end %>
@@ -43,23 +44,23 @@
       <h2 class="text-xl font-bold">問題數量: <span data-stats-target="questionsCount"><%= @survey.questions.count %></span></h2>
       <h2 class="text-xl font-bold">目前顯示: 第<span data-stats-target="currentQuestion">1</span>題</h2>
       <br>
-      <button class="hidden hover:bg-ironGrayHover" data-stats-target="previousPageButton" data-action="click->stats#previousQuestion">上一份</button>
-      <button class="hover:bg-ironGrayHover" data-stats-target="nextPageButton" data-action="click->stats#nextQuestion">下一份</button>
+      <button class="hidden page-button" data-stats-target="previousPageButton" data-action="click->stats#previousQuestion">上一份</button>
+      <button class="page-button" data-stats-target="nextPageButton" data-action="click->stats#nextQuestion">下一份</button>
       跳轉到:<input class="input-jump-to-page" data-action="change->stats#jumpToQuestion" placeholder="輸入頁數"></input>
       <% @survey.questions.each_with_index do |question, questionIndex| %>
         <div data-stats-target="showSingleQuestion", class="hidden">
 
           <table class="table-style">
             <tr>
-              <th class="table-style">編號</th>
-              <th class="table-style"><%= question.title %></th>
+              <th class="th-style">編號</th>
+              <th class="th-style"><%= question.title %></th>
             </tr>
             <% @response_question_answers.each_with_index do |response_question_answer, index| %>
               <% if index % @survey.questions.length === questionIndex %>
                 <tr>
                   <% if response_question_answer.join('  ').present? %>
-                    <th class="table-style"><%= (index/@survey.questions.length)+1 %></th>                
-                    <td class="table-style"><%= response_question_answer.join('  ') %></td>
+                    <th class="th-style"><%= (index/@survey.questions.length)+1 %></th>                
+                    <td class="td-style"><%= response_question_answer.join('  ') %></td>
                   <% end %>  
                 </tr>
               <% end %>

--- a/app/views/surveys/stats.html.erb
+++ b/app/views/surveys/stats.html.erb
@@ -1,54 +1,92 @@
-<h1>TITLE: <%= @survey.title %></h1>
-<h1>DESC:  <%= @survey.description %></h1>
-<h2>TAG:   <%= @survey.tag %></h2>
-<hr>
-
-
-<div data-controller="stats">
-  <button data-action="click->stats#hideAndShow">顯示所有回應</button>
-  <div data-stats-target="showResponses" class="hidden">
-    <h2>填答份數: <span data-stats-target="responsesCount"><%= @survey.responses.count %></span></h2>
-    <h2>目前顯示: 第<span data-stats-target="currentResponse">1</span>份</h2>
-    <% 0.upto(@survey.responses.count-1) do |responseIndex| %>
-      <div data-stats-target="showSingleResponse", class="hidden">
-        <table class="table-auto">
-          <% @responseJsons.each do |responseJson| %>
-            <% if responseJson.as_json["responseIndex"] === responseIndex %>
-              <tr>
-                <th class="bg-gentleYellow text-ironGray"><%= responseJson.as_json["questionTitles"] %></th>
-                <td><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></td>
-              </tr>
-            <% end %>
-          <% end %>
-        </table>
-      </div>
-    <% end %>
-    <button data-stats-target="previousPageButton" data-action="click->stats#previousPage" class="hidden">上一份</button>
-    <button data-stats-target="nextPageButton" data-action="click->stats#nextPage">下一份</button>
-    跳轉到:<input data-action="change->stats#jumpToPage" placeholder="輸入頁數"></input>
+<div data-controller="stats" class="px-1 padding-for-fixed-stats min-hight">
+  <div class="flex mx-2 bg-gentleYellow">
+    <button id="showResponsesBtn" class="stats-tab-button" data-action="click->stats#hideAndShow">所有回應</button><br>
+    <button id="showQuestionsBtn" class="stats-tab-button" data-action="click->stats#hideAndShow">數據統計</button><br>
+    <button id="showChartsBtn" class="stats-tab-button" data-action="click->stats#hideAndShow">統計圖表</button><br>
+    <button class="stats-tab-button"><%= link_to '匯出Excel檔案', stats_survey_path(format: :xlsx) %></button></br>
   </div>
-
-  <hr>
-  <div>
-    <% 0.upto(@chart_count-1) do |chart_index| %>
-      <div id="<%= chart_index %>" class="canvasContainer">
-        <%= select_tag(:chart_type, options_for_select([['長條圖', 'bar'], ['圓餅圖', 'pie'], ['折線圖', 'line']]), data: { action: "change->stats#chartTypeSelect"}) %>
-        <% 0.upto(@chart_types.count-1) do |chart_type_index| %>
-          <div class="hidden canvasArea">
-            <canvas
-            data-controller="chart"
-            data-chart-type-value="<%= @chart_types[chart_type_index] %>"
-            data-chart-data-value="<%= @chart_datas[chart_index].to_json %>"
-            data-chart-options-value="<%= @chart_options[chart_index].to_json %>"
-            data-stats-target="<%= @canvas_target_name[chart_type_index] %>"
-            ></canvas>
-          </div>  
+  <div class="stats-display-area">
+    <h1 class="px-2 mx-2 text-3xl font-bold text-gray-700"><%= @survey.title %></h1>
+    <h2 class="px-2 mx-2 text-lg font-bold text-gray-500"><%= @survey.description %></h2>
+    <br>
+    <div class="mx-4">
+      <% if @survey.tag.present? %>
+        <% @survey.tag.split(',') do |currentTag| %>
+          <h2 class="taglabel"><%= currentTag %></h2>
         <% end %>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+    <br>
+    <div data-stats-target="showResponses" id=0 class="hidden">
+      <h2 class="text-xl font-bold">填答份數: <span data-stats-target="responsesCount"><%= @survey.responses.count %></span></h2>
+      <h2 class="text-xl font-bold">目前顯示: 第<span data-stats-target="currentResponse">1</span>份</h2>
+      <br>
+      <button class="hidden hover:bg-ironGrayHover" data-stats-target="previousPageButton" data-action="click->stats#previousResponse">上一份</button>
+      <button class="hover:bg-ironGrayHover" data-stats-target="nextPageButton" data-action="click->stats#nextResponse">下一份</button>
+      跳轉到:<input class="input-jump-to-page" data-action="change->stats#jumpToResponse" placeholder="輸入頁數"></input>
+      <% 0.upto(@survey.responses.count-1) do |responseIndex| %>
+        <div data-stats-target="showSingleResponse", class="hidden">
+          <table class="table-style">
+            <% @responseJsons.each do |responseJson| %>
+              <% if responseJson.as_json["responseIndex"] === responseIndex %>
+                <tr>
+                  <th class="table-style"><%= responseJson.as_json["questionTitles"] %></th>
+                  <td class="table-style"><%= responseJson.as_json["responseAnswerTitles"].join('  ') %></td>
+                </tr>
+              <% end %>
+            <% end %>
+          </table>
+        </div>
+      <% end %>
+    </div>
+    <div data-stats-target="showQuestions" id=1 class="hidden">
+      <h2 class="text-xl font-bold">問題數量: <span data-stats-target="questionsCount"><%= @survey.questions.count %></span></h2>
+      <h2 class="text-xl font-bold">目前顯示: 第<span data-stats-target="currentQuestion">1</span>題</h2>
+      <br>
+      <button class="hidden hover:bg-ironGrayHover" data-stats-target="previousPageButton" data-action="click->stats#previousQuestion">上一份</button>
+      <button class="hover:bg-ironGrayHover" data-stats-target="nextPageButton" data-action="click->stats#nextQuestion">下一份</button>
+      跳轉到:<input class="input-jump-to-page" data-action="change->stats#jumpToQuestion" placeholder="輸入頁數"></input>
+      <% @survey.questions.each_with_index do |question, questionIndex| %>
+        <div data-stats-target="showSingleQuestion", class="hidden">
+
+          <table class="table-style">
+            <tr>
+              <th class="table-style">編號</th>
+              <th class="table-style"><%= question.title %></th>
+            </tr>
+            <% @response_question_answers.each_with_index do |response_question_answer, index| %>
+              <% if index % @survey.questions.length === questionIndex %>
+                <tr>
+                  <% if response_question_answer.join('  ').present? %>
+                    <th class="table-style"><%= (index/@survey.questions.length)+1 %></th>                
+                    <td class="table-style"><%= response_question_answer.join('  ') %></td>
+                  <% end %>  
+                </tr>
+              <% end %>
+            <% end %>
+          </table>         
+        </div>
+      <% end %>
+    </div>
+    <div data-stats-target="showCharts" class="grid hidden grid-cols-2">
+      <% 0.upto(@chart_count-1) do |chart_index| %>
+        <div id="<%= chart_index %>" class="canvasContainer">
+          <%= select_tag(:chart_type, options_for_select([['長條圖', 'bar'], ['圓餅圖', 'pie'], ['折線圖', 'line']]), data: { action: "change->stats#chartTypeSelect"}) %>
+          <% 0.upto(@chart_types.count-1) do |chart_type_index| %>
+            <div class="hidden canvasArea">
+              <canvas
+              data-controller="chart"
+              data-chart-type-value="<%= @chart_types[chart_type_index] %>"
+              data-chart-data-value="<%= @chart_datas[chart_index].to_json %>"
+              data-chart-options-value="<%= @chart_options[chart_index].to_json %>"
+              data-stats-target="<%= @canvas_target_name[chart_type_index] %>"
+              ></canvas>
+            </div>  
+          <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
 
 <br>
-<%= link_to 'back', surveys_path %>
-<%= link_to 'Download as .xlsx', stats_survey_path(format: :xlsx) %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ module.exports = {
     "softBlue",
     "softNavy",
     "softGray",
+    "irisBlue",
   ],
   darkMode: false, // or 'media' or 'class'
   theme: {
@@ -49,6 +50,7 @@ module.exports = {
         softBlue: "#bfe2e8",
         softNavy: "#6699A1",
         softGray: "#a4b5c4",
+        irisBlue: "#00bcd4",
       },
       outline: {
         ironGrayHover: "3px solid #A5A2A0",


### PR DESCRIPTION
1. stats頁面切版
2. 新增show出每個問題的response list
3. 新增圖表title
4. 新增圖表y軸從0開始並修正格線有小數點
#138 
#139 
<img width="1368" alt="image" src="https://user-images.githubusercontent.com/78979239/171969739-6372558b-30d2-4f56-a672-284d7c417cfa.png">
<img width="1368" alt="image" src="https://user-images.githubusercontent.com/78979239/171969755-1b113d9d-ffba-4257-b068-812d8ec6f4b7.png">
<img width="1368" alt="image" src="https://user-images.githubusercontent.com/78979239/171969796-a75032b0-94b7-4ae6-a1ee-82889a68a12a.png">
